### PR TITLE
Fix for list item display when a filter is used

### DIFF
--- a/src/virtual-repeat.js
+++ b/src/virtual-repeat.js
@@ -315,7 +315,7 @@
             var delta = forward ? newValue.start - oldValue.start
                                 : oldValue.start - newValue.start;
             var endDelta = newEnd >= oldEnd ? newEnd - oldEnd : oldEnd - newEnd;
-            var contiguous = delta < (forward ? oldValue.active : newValue.active);
+            var contiguous = newValue.len === oldValue.len && delta < (forward ? oldValue.active : newValue.active);
             $log.debug('change by %o,%o rows %s', delta, endDelta, forward ? 'forward' : 'backward');
             if( !contiguous ){
               $log.debug('non-contiguous change');
@@ -361,4 +361,3 @@
   }]);
 
 }());
-


### PR DESCRIPTION
When a filtered list is passed to the virtual repeat directive and the filter changes after instantiation, the displayed number of rows is correct  but the items displayed are the first n (n = no. of items in the filtered list).

This change introduces a check on the length of the list and sets contiguous to false if it changed.
