### PR TITLE
Fix for sfVirtualRepeatWatchExpression to guard using the coll variable ...

### DIFF
--- a/src/virtual-repeat.js
+++ b/src/virtual-repeat.js
@@ -277,14 +277,14 @@
 
         function sfVirtualRepeatWatchExpression(scope){
           var coll = scope.$eval(ident.collection);
-          if( coll.length !== state.total ){
+          if( coll && coll.length !== state.total ){
             state.total = coll.length;
             recomputeActive();
           }
           return {
             start: state.firstActive,
             active: state.active,
-            len: coll.length
+            len: coll ? coll.length : 0
           };
         }
 


### PR DESCRIPTION
...when it is undefined or null

Ran into cases in our project where the function was getting called before 'col' was defined. This resulted in null ref exception.
